### PR TITLE
FBFF-97: Use RefreshAdviceService in Graphical Report Call

### DIFF
--- a/apps/assessment/services/advice_services.py
+++ b/apps/assessment/services/advice_services.py
@@ -72,3 +72,15 @@ def delete_advice_item(request, advice_item_id):
     if response.status_code == 204:
         return {"Success": True, "body": None, "status_code": response.status_code}
     return {"Success": False, "body": response.json(), "status_code": response.status_code}
+
+
+def refresh_advice(request, assessment_id, result_affected):
+    data = dict(request.data)
+    data['forceRegenerate'] = result_affected
+    response = requests.post(ASSESSMENT_URL + f'assessment-core/api/assessments/{assessment_id}/refresh-advice',
+                             json=data,
+                             headers={'Authorization': request.headers['Authorization'],
+                                      'Accept-Language': request.headers['Accept-Language']})
+    if response.status_code == 200:
+        return {"Success": True, "body": None, "status_code": response.status_code}
+    return {"Success": False, "body": response.json(), "status_code": response.status_code}


### PR DESCRIPTION
ملاحضات:
در حین تست مواردی رو متوجه شدم که اینجا عنوان میکنم
۱- تست دقیق خصاصا برای دسترسی‌های مجاز نیازمند تست بر روی استیج است.
۲- ویژگی کانفیدنس ولید نباشه سرویس گزارش گرافیکی در سمت بک‌اند خطای نیازمند محاسبه می‌دهد.
۳- شما فرمودید سناریو نال بودن مقدار isCalculateValid میتونه نال باشه. اگر این سناریو رو در نظر بگیریم، سرویس دریافت ارزیابی قبلش به نال پوینتر اکسپشن میخوره. ما نیاز داشتیم که ارزیابی رو برای تشخیص مود لود کنیم.
۴- این رویه تراکنشی نیست. فراخوانی چند API هست. یکم وقت گذاشتم روش ولی اگر نیاز هست که الان انجام بدیم. بنظرم اگر حتی نیازه میتونه در یک تسک دیگه باشه. سخن آخر: نمیدونم بشه چند API رو تراکنشی کرد یا خیر. انجام شده جوابش اومده!